### PR TITLE
Add to ACL

### DIFF
--- a/controller/schema.json
+++ b/controller/schema.json
@@ -3,68 +3,76 @@
   "$id": "https://github.com/osoc24/loama/controller/schema.json",
   "title": "Index configuration",
   "description": "The json schema for the index configuration file inside a Solid data pod",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "properties": {
-      "resource": {
-        "type": "array",
-        "items": {
-          "$ref": "#/$defs/url"
-        },
-        "minItems": 1
-      },
-      "userType": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "url": {
-                "$ref": "#/$defs/url"
-              },
-              "type": {
-                "enum": [
-                  "Group",
-                  "WebId"
-                ]
-              }
+  "type": "object",
+  "properties": {
+    "id": {
+      "$ref": "#/$defs/url"
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/url"
             },
-            "required": [
-              "url",
-              "type"
+            "minItems": 1
+          },
+          "userType": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "$ref": "#/$defs/url"
+                  },
+                  "type": {
+                    "enum": [
+                      "Group",
+                      "WebId"
+                    ]
+                  }
+                },
+                "required": [
+                  "url",
+                  "type"
+                ]
+              },
+              {
+                "type": "boolean"
+              }
             ]
           },
-          {
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Read",
+                "Write",
+                "Append",
+                "Control"
+              ]
+            },
+            "minItems": 1
+          },
+          "isEnabled": {
             "type": "boolean"
           }
-        ]
-      },
-      "permission": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "Read",
-            "Write",
-            "Append",
-            "Control"
-          ]
         },
-        "minItems": 1
-      },
-      "isEnabled": {
-        "type": "boolean"
+        "required": [
+          "resources",
+          "userType",
+          "permissions",
+          "isEnabled"
+        ]
       }
-    },
-    "required": [
-      "resource",
-      "userType",
-      "permission",
-      "isEnabled"
-    ]
+    }
   },
   "$defs": {
     "url": {

--- a/controller/src/index-file.ts
+++ b/controller/src/index-file.ts
@@ -1,0 +1,24 @@
+import {
+  getFile,
+  overwriteFile,
+  saveFileInContainer,
+} from "@inrupt/solid-client";
+import { Session } from "@inrupt/solid-client-authn-browser";
+
+export async function getIndexFile(session: Session, pod: string) {
+  return getFile(`${pod}index.json`, { fetch: session.fetch })
+    .catch((error) => {
+      if (
+        error ===
+        'Error: Fetching the File failed: [404] [] {"name":"NotFoundHttpError","message":"","statusCode":404,"errorCode":"H404","details":{}}.'
+      ) {
+        return saveFileInContainer(
+          pod,
+          new File(["[]"], "index.json", { type: "application/json" }),
+          { fetch: session.fetch }
+        );
+      }
+    })
+    .then((res) => res?.text())
+    .then((text) => JSON.parse(text ?? ""));
+}

--- a/controller/src/index-file.ts
+++ b/controller/src/index-file.ts
@@ -1,24 +1,130 @@
 import {
+  AccessModes,
+  FetchError,
   getFile,
   overwriteFile,
   saveFileInContainer,
 } from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-browser";
+import { Index, IndexItem, Permission, url, UserTypeObject } from "./types";
+import {
+  setAgentAccess,
+  setPublicAccess,
+} from "@inrupt/solid-client/universal";
 
-export async function getIndexFile(session: Session, pod: string) {
-  return getFile(`${pod}index.json`, { fetch: session.fetch })
-    .catch((error) => {
-      if (
-        error ===
-        'Error: Fetching the File failed: [404] [] {"name":"NotFoundHttpError","message":"","statusCode":404,"errorCode":"H404","details":{}}.'
-      ) {
+/**
+ * Get the index file for a given pod. If it can't be found create an empty one.
+ */
+export async function getOrCreateIndex(
+  session: Session,
+  pod: url
+): Promise<Index> {
+  const indexUrl = `${pod}index.json`;
+  return getFile(indexUrl, { fetch: session.fetch })
+    .catch((error: FetchError) => {
+      if (error.statusCode === 404) {
         return saveFileInContainer(
           pod,
-          new File(["[]"], "index.json", { type: "application/json" }),
+          indexToIndexFile({ id: indexUrl, items: [] } as Index),
           { fetch: session.fetch }
         );
       }
     })
     .then((res) => res?.text())
-    .then((text) => JSON.parse(text ?? ""));
+    .then((text) => JSON.parse(text ?? "{}"));
+}
+
+/**
+ * NOTE: Currently, it doesn't do any recursive permission setting on containers
+ *
+ * Side effects:
+ * - The remote ACL is updated
+ * - The remote index file is synced
+ */
+export async function addPermissions(
+  session: Session,
+  index: Index,
+  resources: url[],
+  user: UserTypeObject,
+  permissions: Permission[]
+): Promise<Index> {
+  const newItem: IndexItem = {
+    isEnabled: true,
+    permissions: permissions,
+    resources: resources,
+    userType: user,
+  };
+
+  // NOTE: No checks are performed to see if the item isn't already present
+  index.items.push(newItem);
+
+  // Update the ACL
+  await Promise.all(
+    resources.map(async (resource) => {
+      if (typeof user === "boolean") {
+        return await setPublicAccess(
+          resource,
+          permissionsToAccessModes(permissions),
+          { fetch: session.fetch }
+        );
+      } else {
+        return await setAgentAccess(
+          resource,
+          user.url,
+          permissionsToAccessModes(permissions),
+          {
+            fetch: session.fetch,
+          }
+        );
+      }
+    })
+  );
+
+  await updateRemoteIndex(session, index);
+
+  return index;
+}
+
+/**
+ * Overwrite the index file in the pod with the given `index`.
+ * This disregards any potential changes in the remote that aren't reflected here.
+ */
+async function updateRemoteIndex(session: Session, index: Index) {
+  return overwriteFile(index.id, indexToIndexFile(index), {
+    fetch: session.fetch,
+  });
+}
+
+function indexToIndexFile(index: Index): File {
+  return new File([JSON.stringify(index)], "index.json", {
+    type: "application/json",
+  });
+}
+
+/**
+ * Maps the permission structure that the controller uses to the one from `@inrupt/solid-client`.
+ */
+function permissionsToAccessModes(
+  permissions: Permission[]
+): Partial<AccessModes> {
+  const accessModes: Partial<AccessModes> = {};
+
+  for (const permission of permissions) {
+    switch (permission) {
+      case Permission.Append:
+        accessModes.append = true;
+        break;
+      case Permission.Control:
+        accessModes.controlRead = true;
+        accessModes.controlWrite = true;
+      case Permission.Read:
+        accessModes.read = true;
+        break;
+      case Permission.Write:
+        accessModes.write = true;
+        break;
+    }
+  }
+
+  return accessModes;
 }

--- a/controller/src/index.ts
+++ b/controller/src/index.ts
@@ -1,3 +1,3 @@
 export { sayHello } from "./hello-world";
 export { listPods, listPod } from "./pod";
-export { getIndexFile } from "./index-file";
+export { getOrCreateIndex, addPermissions } from "./index-file";

--- a/controller/src/index.ts
+++ b/controller/src/index.ts
@@ -1,2 +1,3 @@
 export { sayHello } from "./hello-world";
 export { listPods, listPod } from "./pod";
+export { getIndexFile } from "./index-file";

--- a/controller/src/pod.ts
+++ b/controller/src/pod.ts
@@ -10,6 +10,7 @@ import {
   getPublicAccess,
 } from "@inrupt/solid-client/universal";
 import { Session } from "@inrupt/solid-client-authn-browser";
+import { url } from "./types";
 
 /**
  * List the pods that are from the currently authenticated user.
@@ -18,11 +19,11 @@ import { Session } from "@inrupt/solid-client-authn-browser";
  */
 export async function listPods(session: Session): Promise<
   {
-    pod: string;
+    pod: url;
     things: {
-      url: string;
-      properties: string[];
-      accessModes: Record<string, AccessModes>;
+      url: url;
+      properties: url[];
+      accessModes: Record<url, AccessModes>;
     }[];
   }[]
 > {
@@ -32,18 +33,18 @@ export async function listPods(session: Session): Promise<
   return Promise.all(pods.map(async (url) => listPod(session, url)));
 }
 
-export async function listPod(session: Session, url: string) {
+export async function listPod(session: Session, url: url) {
   return { pod: url, things: await listThings(session, url) };
 }
 
 async function listThings(
   session: Session,
-  url: string
+  url: url
 ): Promise<
   {
-    url: string;
-    properties: string[];
-    accessModes: Record<string, AccessModes>;
+    url: url;
+    properties: url[];
+    accessModes: Record<url, AccessModes>;
   }[]
 > {
   const dataset = await getSolidDataset(url, { fetch: session.fetch });
@@ -64,8 +65,8 @@ async function listThings(
  */
 async function getAccessModes(
   session: Session,
-  url: string
-): Promise<Record<string, AccessModes>> {
+  url: url
+): Promise<Record<url, AccessModes>> {
   return Promise.all([
     getAgentAccessAll(url, { fetch: session.fetch }) as Promise<
       Record<string, AccessModes>

--- a/controller/src/types.ts
+++ b/controller/src/types.ts
@@ -1,0 +1,38 @@
+/**
+ * The json schema for the index configuration file inside a Solid data pod.
+ * Generated from `schema.json`.
+ */
+
+export interface Index {
+  id: url;
+  items: IndexItem[];
+}
+
+export interface IndexItem {
+  isEnabled: boolean;
+  permissions: Permission[];
+  resources: string[];
+  userType: boolean | UserTypeObject;
+  [property: string]: any;
+}
+
+export enum Permission {
+  Append = "Append",
+  Control = "Control",
+  Read = "Read",
+  Write = "Write",
+}
+
+export interface UserTypeObject {
+  name?: string;
+  type: Type;
+  url: string;
+  [property: string]: any;
+}
+
+export enum Type {
+  Group = "Group",
+  WebID = "WebId",
+}
+
+export type url = string;

--- a/loama/src/App.vue
+++ b/loama/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <header>
-    LOAMA
+    <h1>LOAMA</h1>
   </header>
 
   <RouterView />

--- a/loama/src/components/PodList.vue
+++ b/loama/src/components/PodList.vue
@@ -31,12 +31,13 @@
 
 <script setup lang="ts">
 import { store } from "@/store";
-import { listPods, getIndexFile } from "loama-controller";
+import { listPods, getOrCreateIndex, addPermissions } from "loama-controller";
+import { Permission } from "loama-controller/dist/types";
 
 const pods = await listPods(store.session);
 
-const indexFile = await getIndexFile(store.session, pods[0].pod);
-console.log(indexFile)
+const indexFile = await getOrCreateIndex(store.session, pods[0].pod); // .then((index) => addPermissions(store.session, index, ["example.com"], true, [Permission.Read]))
+// const indexFile = await getOrCreateIndex(store.session, pods[0].pod).then((index) => addPermissions(store.session, index, ["https://css12.onto-deside.ilabt.imec.be/osoc1/README"], true, [Permission.Read, Permission.Write]))
 
 // const pods = [await listPod(store.session, "https://css12.onto-deside.ilabt.imec.be/osoc5/")]
 </script>

--- a/loama/src/components/PodList.vue
+++ b/loama/src/components/PodList.vue
@@ -26,18 +26,22 @@
             <h4>{{ `${pod.pod}index.json` }}</h4>
             {{ indexFile }}
         </template>
+        <button @click="addReadmePermissions">Add README permissions</button>
     </div>
 </template>
 
 <script setup lang="ts">
 import { store } from "@/store";
+import type { Session } from "@inrupt/solid-client-authn-browser";
 import { listPods, getOrCreateIndex, addPermissions } from "loama-controller";
 import { Permission } from "loama-controller/dist/types";
+import { ref } from "vue";
 
-const pods = await listPods(store.session);
+const pods = await listPods(store.session as Session);
 
-const indexFile = await getOrCreateIndex(store.session, pods[0].pod); // .then((index) => addPermissions(store.session, index, ["example.com"], true, [Permission.Read]))
-// const indexFile = await getOrCreateIndex(store.session, pods[0].pod).then((index) => addPermissions(store.session, index, ["https://css12.onto-deside.ilabt.imec.be/osoc1/README"], true, [Permission.Read, Permission.Write]))
+const indexFile = ref(await getOrCreateIndex(store.session as Session, pods[0].pod)); // .then((index) => addPermissions(store.session, index, ["example.com"], true, [Permission.Read]))
 
 // const pods = [await listPod(store.session, "https://css12.onto-deside.ilabt.imec.be/osoc5/")]
+
+const addReadmePermissions = async () => indexFile.value = await addPermissions(store.session as Session, indexFile.value, ["https://css12.onto-deside.ilabt.imec.be/osoc1/README"], true, [Permission.Read, Permission.Write]);
 </script>

--- a/loama/src/components/PodList.vue
+++ b/loama/src/components/PodList.vue
@@ -1,41 +1,42 @@
 <template>
     <div>
-        Pods:
-        <dl>
-            <template v-for="pod in pods" :key="pod.pod">
-                <dt>{{ pod.pod }}</dt>
-                <dd>
-                    <table>
-                        <thead>
-                            <th>URL</th>
-                            <th>Properties</th>
-                            <th>Access Modes</th>
-                        </thead>
-                        <tbody>
-                            <tr v-for="thing in pod.things" :key="thing.url">
-                                <td>{{ thing.url }}</td>
-                                <td>
-                                    <ul>
-                                        <li v-for="property in thing.properties" :key="property">{{ property }}</li>
-                                    </ul>
-                                </td>
-                                <td>
-                                    {{ thing.accessModes }}
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </dd>
-            </template>
-        </dl>
+        <h2>Pods:</h2>
+        <template v-for="pod in pods" :key="pod.pod">
+            <h4>{{ pod.pod }}</h4>
+            <table>
+                <thead>
+                    <th>URL</th>
+                    <th>Properties</th>
+                    <th>Access Modes</th>
+                </thead>
+                <tbody>
+                    <tr v-for="thing in pod.things" :key="thing.url">
+                        <td>{{ thing.url }}</td>
+                        <td>
+                            <ul>
+                                <li v-for="property in thing.properties" :key="property">{{ property }}</li>
+                            </ul>
+                        </td>
+                        <td>
+                            {{ thing.accessModes }}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h4>{{ `${pod.pod}index.json` }}</h4>
+            {{ indexFile }}
+        </template>
     </div>
 </template>
 
 <script setup lang="ts">
 import { store } from "@/store";
-import { listPods, listPod } from "loama-controller";
+import { listPods, getIndexFile } from "loama-controller";
 
 const pods = await listPods(store.session);
+
+const indexFile = await getIndexFile(store.session, pods[0].pod);
+console.log(indexFile)
 
 // const pods = [await listPod(store.session, "https://css12.onto-deside.ilabt.imec.be/osoc5/")]
 </script>

--- a/loama/src/views/HomeView.vue
+++ b/loama/src/views/HomeView.vue
@@ -2,6 +2,7 @@
   <main>
     <button @click="logout">Logout</button>
 
+    <hr />
     <Suspense>
       <PodList />
 


### PR DESCRIPTION
Fixes #12 

Some caveats are provided inside `index-file.ts`, about functionality that is currently missing.

I did the following flow to test it all:
1. Make sure there's no index file yet (via Penny)
2. Do `await getOrCreateIndex(store.session, pods[0].pod).then((index) => addPermissions(store.session, index, ["https://css12.onto-deside.ilabt.imec.be/osoc1/README"], true, [Permission.Read, Permission.Write]))` inside LOAMA
3. See the updated index.json [inside Penny](https://penny.vincenttunru.com/explore?url=https%3A%2F%2Fcss12.onto-deside.ilabt.imec.be%2Fosoc1%2Findex.json)
4. See that the public access to [the README](https://penny.vincenttunru.com/explore/?url=https%3A%2F%2Fcss12.onto-deside.ilabt.imec.be%2Fosoc1%2FREADME.acl) is now updated to the given permissions

If there's no index file, one is created, the same applies for the ACL of the resource for which we want to change the permissions.
